### PR TITLE
sched/pthread: Use -1 instead of 0 as PID for unclaimed mutexes

### DIFF
--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -165,7 +165,7 @@
 
 /* Definitions to map some non-standard, BSD thread management interfaces to
  * the non-standard Linux-like prctl() interface.  Since these are simple
- * mappings to prctl, they will return 0 sucess and -1 on failure with the
+ * mappings to prctl, they will return 0 on sucess and -1 on failure with the
  * err number in errno.  This is an inconsistency with out pthread interfaces.
  */
 
@@ -203,7 +203,6 @@ extern "C" {
 
 typedef int pthread_key_t;
 typedef FAR void *pthread_addr_t;
-typedef pthread_addr_t any_t;
 
 typedef pthread_addr_t (*pthread_startroutine_t)(pthread_addr_t);
 typedef pthread_startroutine_t pthread_func_t;
@@ -222,7 +221,7 @@ struct pthread_region_s {
  * @brief Structure of pthread attr configuration
  */
 struct pthread_attr_s {
-	size_t stacksize;		/* Size of the stack allocated for the pthead */
+	size_t stacksize;		/* Size of the stack allocated for the pthread */
 	int16_t priority;		/* Priority of the pthread */
 	uint8_t policy;			/* Pthread scheduler policy */
 	uint8_t inheritsched;	/* Inherit parent prio/policy? */
@@ -271,9 +270,9 @@ struct pthread_mutex_s {
 typedef struct pthread_mutex_s pthread_mutex_t;
 
 #ifdef CONFIG_MUTEX_TYPES
-#define PTHREAD_MUTEX_INITIALIZER {0, SEM_INITIALIZER(1), PTHREAD_MUTEX_DEFAULT, 0}
+#define PTHREAD_MUTEX_INITIALIZER {-1, SEM_INITIALIZER(1), PTHREAD_MUTEX_DEFAULT, 0}
 #else
-#define PTHREAD_MUTEX_INITIALIZER {0, SEM_INITIALIZER(1)}
+#define PTHREAD_MUTEX_INITIALIZER {-1, SEM_INITIALIZER(1)}
 #endif
 
 /**
@@ -424,7 +423,7 @@ void pthread_yield(void);
  * @details [SYSTEM CALL API]
  * @since Tizen RT v1.0
  */
-#define pthread_equal(t1, t2) (t1 == t2)
+#define pthread_equal(t1, t2) ((t1) == (t2))
 
 /* Thread scheduling parameters */
 /**

--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -275,7 +275,7 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 				} else {
 					/* Give up the mutex */
 
-					mutex->pid = 0;
+					mutex->pid = -1;
 					ret = pthread_givesemaphore((sem_t *)&mutex->sem);
 					if (ret) {
 						/* Restore interrupts  (pre-emption will be enabled when

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -130,7 +130,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		svdbg("Give up mutex / take cond\n");
 
 		sched_lock();
-		mutex->pid = 0;
+		mutex->pid = -1;
 		ret = pthread_givesemaphore((sem_t *)&mutex->sem);
 
 		/* Take the semaphore */
@@ -143,7 +143,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		svdbg("Reacquire mutex...\n");
 		ret |= pthread_takesemaphore((sem_t *)&mutex->sem);
 		if (!ret) {
-			mutex->pid = getpid();;
+			mutex->pid = getpid();
 		}
 	}
 

--- a/os/kernel/pthread/pthread_mutexdestroy.c
+++ b/os/kernel/pthread/pthread_mutexdestroy.c
@@ -122,7 +122,7 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
 
 		/* Is the semaphore available? */
 
-		if (mutex->pid != 0) {
+		if (mutex->pid != -1) {
 			ret = EBUSY;
 		} else {
 			/* Destroy the semaphore */


### PR DESCRIPTION
Update Nuttx commit d16053c33cdf3f570d347b29f809cd69a6d916c0