### PR TITLE
remove duplicated type definition for uint

### DIFF
--- a/os/include/sys/types.h
+++ b/os/include/sys/types.h
@@ -319,8 +319,6 @@ typedef CODE int (*preapp_main_t)(int argc, char *argv[]);
 
 #endif
 
-typedef unsigned int uint;
-
 /****************************************************************************
  * Global Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
It is at line 298 and 322 and it should be in __ASSEMBLY__.